### PR TITLE
Adds a phonetic reading to the Japanese parser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,15 @@ DB_FILENAME=%kernel.project_dir%/data/lute.db
 
 
 # --------------------------------------------
+# Customizing appearance using CSS.
+# Multi-line data must be enclosed in quotes.
+
+CUSTOM_STYLES="
+  /* Example: changing the text size when reading */
+  span.textitem { font-size: 16px; }
+"
+
+# --------------------------------------------
 # Backup db and user images.
 
 BACKUP_ENABLED=false

--- a/.env.example.docker
+++ b/.env.example.docker
@@ -1,11 +1,23 @@
 # Your personal settings for docker -- copy this file to .env
 # See https://github.com/jzohrab/lute/wiki/Configuration for notes about this file.
 
+
+# --------------------------------------------
+# Customizing appearance.
+# Multi-line data must be enclosed in quotes.
+
+CUSTOM_STYLES="
+  /* Example: changing the text size when reading */
+  span.textitem { font-size: 16px; }
+"
+
+# --------------------------------------------
 # Backup db and user images.
 BACKUP_HOST_DIR=~/Dropbox/LuteBackup/
 BACKUP_ENABLED=false
 BACKUP_AUTO=yes
 BACKUP_WARN=yes
+
 
 # --------------------------------------------
 # Don't change anything after this :-)

--- a/.env.example.docker
+++ b/.env.example.docker
@@ -9,12 +9,14 @@ BACKUP_WARN=yes
 
 # --------------------------------------------
 # Don't change anything after this :-)
+# The paths given below are set during the Dockerfile build,
+# and in the docker-compose.yml.
 
-# The db.  A host folder must be mounted to the container's /data dir.
-DB_FILENAME=/data/lute.db
+# The db.  A host folder must be mounted to the container's /lute/data dir.
+DB_FILENAME=/lute/data/lute.db
 
-# The backup folder.  A host folder must be mounted to the container's /backup dir.
-BACKUP_DIR=/backup
+# The backup folder.  A host folder must be mounted to the container's /lute/backup dir.
+BACKUP_DIR=/lute/backup
 
 DATABASE_URL=sqlite:///${DB_FILENAME}
 APP_SECRET=not_secret_at_all

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
     && php -r "unlink('composer-setup.php');"
 
-WORKDIR /
+WORKDIR /lute
 
 COPY ./composer.* ./
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.9"
 
+# Note: Docker users should create an .env file
+# using the .env.example.docker as a template.
+
 services:
   lute:
     build:
@@ -10,7 +13,9 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - ./data:/data
-      - ${BACKUP_HOST_DIR}:/backup
-    working_dir: /public
+      # The host directories are mounted to the folders
+      # specified in .env
+      - ./data:/lute/data
+      - ${BACKUP_HOST_DIR}:/lute/backup
+    working_dir: /lute/public
     command: ["php", "-S", "0.0.0.0:8000"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2023-04-17 v2.0.0
+
+Big changes:  Moving from MySQL to Sqlite, and adding Docker support.
+
+Users of v1 will need to export CSV data from v1.  See the wiki: https://github.com/jzohrab/lute/wiki/Migrating-from-v1-to-v2
+
+Big user-facing changes
+
+* Change from Mysql to Sqlite, including .env file configuration
+* Move all user specific files (db, user images) to /data subdirectory
+* Add CSV import for v1 users
+* Add Docker support
+
+Smaller user-facing changes
+
+* Remove dashed underline for ignored words, no need for clutter.
+* Read custom styles from .env file.
+* Add convenience links on last page of book reading.
+* Demo data is automatically loaded in new installation
+
+Back end changes:
+
+* Remove all mysql-related code
+* Revamp code as needed for Sqlite-specific sql
+
+
 ## 2023-04-15 v1.3 (end of life of Lute V1)
 
 Feature changes:

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -208,11 +208,11 @@
  
  span.status98
  {
-   /*
+   /* no styling, just regular text.
    background-color: #F8F8F8;
+   border-bottom: dashed 1px #000000;
    color: #000000;
    */
-   border-bottom: dashed 1px #000000;
  }
 
  span.textsentence {

--- a/src/Controller/ReadingController.php
+++ b/src/Controller/ReadingController.php
@@ -100,6 +100,10 @@ class ReadingController extends AbstractController
         $text = implode($zws, $cleanedparts);
 
         $termdto = $facade->loadDTO($lid, $text);
+        if ($termdto->language->getLgParserType() == 'japanese') {
+            $termdto->Romanization = $termdto->language->
+            getParser()->getReading($text, $termdto->language);
+        }
         $form = $this->createForm(TermDTOType::class, $termdto, [ 'hide_sentences' => true ]);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/ReadingController.php
+++ b/src/Controller/ReadingController.php
@@ -100,10 +100,6 @@ class ReadingController extends AbstractController
         $text = implode($zws, $cleanedparts);
 
         $termdto = $facade->loadDTO($lid, $text);
-        if ($termdto->language->getLgParserType() == 'japanese') {
-            $termdto->Romanization = $termdto->language->
-            getParser()->getReading($text, $termdto->language);
-        }
         $form = $this->createForm(TermDTOType::class, $termdto, [ 'hide_sentences' => true ]);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Domain/AbstractParser.php
+++ b/src/Domain/AbstractParser.php
@@ -8,4 +8,10 @@ abstract class AbstractParser {
 
     abstract public function getParsedTokens(string $text, Language $lang);
 
+    /**
+     * Many writing systems are phonetic and do not need a phonetic reading.
+     */
+    public function getReading(string $text) {
+        return '';
+    }
 }

--- a/src/Domain/JapaneseParser.php
+++ b/src/Domain/JapaneseParser.php
@@ -97,4 +97,29 @@ class JapaneseParser extends AbstractParser {
         return $tokens;
     }
 
+    public function getReading(string $text, Language $lang) {
+        // Japanese is an exception
+        $mecab_file = tempnam(sys_get_temp_dir(), "mecab_to_db");
+        $mecab_args = ' -O yomi ';
+        if (file_exists($mecab_file)) { 
+            unlink($mecab_file); 
+        }
+        $fp = fopen($mecab_file, 'w');
+        fwrite($fp, $text . "\n");
+        fclose($fp);
+        $mecab = JapaneseParser::MeCab_command($mecab_args);
+        $handle = popen($mecab . $mecab_file, "r");
+        // $mecab_str Output string
+        $mecab_str = '';
+        while (($line = fgets($handle, 4096)) !== false) {
+            $mecab_str .= $line; 
+        }
+        if (!feof($handle)) {
+            echo "Error: unexpected fgets() fail\n";
+        }
+        pclose($handle);
+        unlink($mecab_file);
+        return $mecab_str;
+    }
+
 }

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -361,6 +361,11 @@ class Term
             $f->ParentText = $p->getText();
         }
 
+
+        if (($f->Romanization ?? '') == '') {
+            $f->Romanization = $f->language->getParser()->getReading($f->Text);
+        }
+
         foreach ($this->getTermTags() as $tt) {
             $f->termTags[] = $tt->getText();
         }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -23,8 +23,12 @@
     <link rel="stylesheet" type="text/css" href="/css/jquery.tagit.css" />
     <link rel="stylesheet" type="text/css" href="/css/datatables.min.css" />
     <link rel="stylesheet" type="text/css" href="/css/styles.css" />
-    <link rel="stylesheet" type="text/css" href="/css/styles-overrides.css" />
-    
+
+    <style>
+      /* Overrides specified in .env CUSTOM_STYLES. */
+      {{ app.request.server.get('CUSTOM_STYLES') | raw }}
+    </style>
+
     <script type="text/javascript" src="/js/jquery.js" charset="utf-8"></script>
     <script type="text/javascript" src="/js/jquery.scrollTo.min.js" charset="utf-8"></script>
     <script type="text/javascript" src="/js/jquery-ui.min.js"  charset="utf-8"></script>

--- a/templates/book/index.html.twig
+++ b/templates/book/index.html.twig
@@ -20,7 +20,8 @@
 </table>
 
 {% if status == 'Active' %}
-<a href="{{ path('app_book_new') }}">Create new</a>
+<a href="{{ path('app_book_new') }}">Create new</a> |
+<a href="{{ path('app_book_import_webpage') }}">Import web page</a>
 {% endif %}
 
 {# Hidden form for archive, unarchive, delete. #}

--- a/templates/read/index.html.twig
+++ b/templates/read/index.html.twig
@@ -101,6 +101,12 @@
 
     {% if pagenum == pagecount %}
     <h2>&#127881;</h2>
+    <p>
+      <a href="" onclick="$('#actionposter').submit(); return false;">Archive book</a> | 
+      <a href="/book/index">Book listing</a>
+    </p>
+
+    <form id="actionposter" method="post" action="/book/{{ book.ID }}/archive"></form>
     {% endif %}
 
   </div>


### PR DESCRIPTION
Hi Jeff!

This PR introduces an automated completion of the phonetic reading field for Japanese (in katakana), using MeCab capabilities. I used it extensively as it makes Japanese language learning much easier, I have seen no issue as far as I can tell.

When a user clicks a Japanese term, the server loads the term form with the "romanization" field completed. It minimal but it's a great deal for Japanese learners.

Without this system, you usually have to click a word (for instance 食べる), go to <https://jisho.org>, copy past the expression with furigana (``た 食べる`` is then pasted), then remove any kanji and concatenate the string to get your final ``たべる``. 

I hope I got you convinced!
